### PR TITLE
Add chain id in the provision's signature

### DIFF
--- a/archethic/config.js
+++ b/archethic/config.js
@@ -1,7 +1,19 @@
 export default {
-  factorySeed: "factory",
-  userSeed: "user",
-  endpoint: "http://127.0.0.1:4000",
-  // Genesis address of seed "protocolFee"
-  protocolFeeAddress: "000001F449ABE3971623E30C10DA5E692DFCF9C795E4E0BC66BCD130F3FC5553552E"
+  environments: {
+    local: {
+      endpoint: "http://127.0.0.1:4000",
+      availableEvmNetworks: ["local"],
+      defaultChainId: 1337,
+      factorySeed: "factory",
+      userSeed: "user",
+      // Genesis address of seed "protocolFee"
+      protocolFeeAddress: "000001F449ABE3971623E30C10DA5E692DFCF9C795E4E0BC66BCD130F3FC5553552E"
+    }
+  },
+  evmNetworks: {
+    local: {
+      endpoint: "http://127.0.0.1:8545",
+      chainId: 1337
+    }
+  }
 }

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -32,7 +32,7 @@ end
 # Archethic => EVM : Request secret hash #
 ##########################################
 
-condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address), as: [
+condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address, _chain_id), as: [
   type: "contract",
   code: valid_signed_code?(end_time, amount, user_address),
   timestamp: end_time > Time.now(),
@@ -44,7 +44,7 @@ condition triggered_by: transaction, on: request_secret_hash(end_time, amount, u
   )
 ]
 
-actions triggered_by: transaction, on: request_secret_hash(end_time, _amount, _user_address) do
+actions triggered_by: transaction, on: request_secret_hash(end_time, _amount, _user_address, chain_id) do
   # Here delete old secret that hasn't been used before endTime
   contract_content = Contract.call_function(#STATE_ADDRESS#, "get_state", [])
 
@@ -59,10 +59,14 @@ actions triggered_by: transaction, on: request_secret_hash(end_time, _amount, _u
   secret_hash = Crypto.hash(secret, "sha256")
 
   # Build signature for EVM decryption
-  signature = sign_for_evm(secret_hash)
+  signature = sign_for_evm(secret_hash, chain_id)
 
   # Add secret and signature in content
-  htlc_map = [hmac_address: transaction.address, end_time: end_time]
+  htlc_map = [
+    hmac_address: transaction.address,
+    end_time: end_time,
+    chain_id: chain_id
+  ]
 
   htlc_genesis_address = Chain.get_genesis_address(transaction.address)
 
@@ -112,7 +116,7 @@ actions triggered_by: transaction, on: reveal_secret(htlc_genesis_address) do
   contract_content = Map.delete(contract_content, htlc_genesis_address)
 
   secret = Crypto.hmac(htlc_map.hmac_address)
-  signature = sign_for_evm(secret)
+  signature = sign_for_evm(secret, htlc_map.chain_id)
 
   Contract.add_recipient address: #STATE_ADDRESS#, action: "update_state", args: [contract_content]
   Contract.add_recipient address: htlc_genesis_address, action: "reveal_secret", args: [secret, signature]
@@ -159,9 +163,13 @@ fun valid_signed_code?(end_time, amount, user_address) do
   Code.is_same?(expected_code, transaction.code)
 end
 
-fun sign_for_evm(data) do
+fun sign_for_evm(data, chain_id) do
+  # Perform a first hash to combine data and chain_id
+  hash_abi = Evm.abi_encode("(bytes32,uint)", [data, chain_id])
+  combined_hash = Crypto.hash(hash_abi, "keccak256")
+
   prefix = String.to_hex("\x19Ethereum Signed Message:\n32")
-  signature_payload = Crypto.hash("#{prefix}#{data}", "keccak256")
+  signature_payload = Crypto.hash("#{prefix}#{combined_hash}", "keccak256")
 
   sig = Crypto.sign_with_recovery(signature_payload)
 

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -32,7 +32,7 @@ end
 # Archethic => EVM : Request secret hash #
 ##########################################
 
-condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address, _chain_id), as: [
+condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address, chain_id), as: [
   type: "contract",
   code: valid_signed_code?(end_time, amount, user_address),
   timestamp: end_time > Time.now(),
@@ -41,7 +41,8 @@ condition triggered_by: transaction, on: request_secret_hash(end_time, amount, u
     previous_address = Chain.get_previous_address()
     balance = Chain.get_token_balance(previous_address, #TOKEN_ADDRESS#)
     balance >= amount
-  )
+  ),
+  content: List.in?([#CHAIN_IDS#], chain_id)
 ]
 
 actions triggered_by: transaction, on: request_secret_hash(end_time, _amount, _user_address, chain_id) do

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -31,7 +31,7 @@ end
 # Archethic => EVM : Request secret hash #
 ##########################################
 
-condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address, _chain_id), as: [
+condition triggered_by: transaction, on: request_secret_hash(end_time, amount, user_address, chain_id), as: [
   type: "contract",
   code: valid_signed_code?(end_time, amount, user_address),
   timestamp: end_time > Time.now(),
@@ -40,7 +40,8 @@ condition triggered_by: transaction, on: request_secret_hash(end_time, amount, u
     previous_address = Chain.get_previous_address()
     balance = Chain.get_uco_balance(previous_address)
     balance >= amount
-  )
+  ),
+  content: List.in?([#CHAIN_IDS#], chain_id)
 ]
 
 actions triggered_by: transaction, on: request_secret_hash(end_time, _amount, _user_address, chain_id) do

--- a/archethic/deploy_chargeable_htlc.js
+++ b/archethic/deploy_chargeable_htlc.js
@@ -1,11 +1,7 @@
 import Archethic, { Crypto, Utils } from "archethic"
 import config from "./config.js"
 
-if (!config.endpoint || !config.userSeed || !config.factorySeed) {
-  console.log("Invalid config !")
-  console.log("Config needs poolSeed, endpoint, userSeed and factorySeed")
-  process.exit(1)
-}
+const env = config.environments.local
 
 const args = []
 process.argv.forEach(function(val, index, _array) { if (index > 1) { args.push(val) } })
@@ -16,9 +12,13 @@ if (args.length != 5) {
   process.exit(1)
 }
 
-main(config.endpoint, config.userSeed, config.factorySeed)
+main()
 
-async function main(endpoint, userSeed, factorySeed) {
+async function main() {
+  const endpoint = env.endpoint
+  const userSeed = env.userSeed
+  const factorySeed = env.factorySeed
+
   const token = args[0]
   const seed = args[1]
   const endTime = parseInt(args[2])

--- a/archethic/deploy_factory.js
+++ b/archethic/deploy_factory.js
@@ -2,15 +2,15 @@ import fs from "fs"
 import Archethic, { Crypto, Utils } from "archethic"
 import config from "./config.js"
 
-if (!config.endpoint || !config.factorySeed || !config.protocolFeeAddress) {
-  console.log("Invalid config !")
-  console.log("Config needs endpoint and factorySeed")
-  process.exit(1)
-}
+const env = config.environments.local
 
-main(config.endpoint, config.factorySeed, config.protocolFeeAddress)
+main()
 
-async function main(endpoint, seed, protocolFeeAddress) {
+async function main() {
+  const endpoint = env.endpoint
+  const seed = env.factorySeed
+  const protocolFeeAddress = env.protocolFeeAddress
+
   const archethic = new Archethic(endpoint)
   await archethic.connect()
 

--- a/archethic/deploy_signed_htlc.js
+++ b/archethic/deploy_signed_htlc.js
@@ -1,11 +1,7 @@
 import Archethic, { Crypto, Utils } from "archethic"
 import config from "./config.js"
 
-if (!config.endpoint || !config.userSeed || !config.factorySeed) {
-  console.log("Invalid config !")
-  console.log("Config needs endpoint, userSeed and factorySeed")
-  process.exit(1)
-}
+const env = config.environments.local
 
 const args = []
 process.argv.forEach(function(val, index, _array) { if (index > 1) { args.push(val) } })
@@ -16,9 +12,14 @@ if (args.length != 4) {
   process.exit(1)
 }
 
-main(config.endpoint, config.userSeed, config.factorySeed)
+main()
 
-async function main(endpoint, userSeed, factorySeed) {
+async function main() {
+  const endpoint = env.endpoint
+  const userSeed = env.userSeed
+  const factorySeed = env.factorySeed
+  const chainId = env.defaultChainId
+
   const token = args[0]
   const seed = args[1]
   const endTime = parseInt(args[2])
@@ -50,7 +51,7 @@ async function main(endpoint, userSeed, factorySeed) {
   const tx = archethic.transaction.new()
     .setType("contract")
     .setCode(htlcCode)
-    .addRecipient(poolGenesisAddress, "request_secret_hash", [endTime, amount, userAddress])
+    .addRecipient(poolGenesisAddress, "request_secret_hash", [endTime, amount, userAddress, chainId])
     .addOwnership(encryptedSeed, authorizedKeys)
     .build(seed, index)
     .originSign(Utils.originPrivateKey)

--- a/archethic/request_secret.js
+++ b/archethic/request_secret.js
@@ -1,11 +1,7 @@
 import Archethic, { Crypto, Utils } from "archethic"
 import config from "./config.js"
 
-if (!config.endpoint || !config.userSeed) {
-  console.log("Invalid config !")
-  console.log("Config needs endpoint and userSeed")
-  process.exit(1)
-}
+const env = config.environments.local
 
 const args = []
 process.argv.forEach(function(val, index, _array) { if (index > 1) { args.push(val) } })
@@ -16,9 +12,12 @@ if (args.length != 2) {
   process.exit(1)
 }
 
-main(config.endpoint, config.userSeed)
+main()
 
-async function main(endpoint, seed) {
+async function main() {
+  const endpoint = env.endpoint
+  const seed = env.userSeed
+
   const poolGenesisAddress = args[0]
   const htlcGenesisAddress = args[1]
 

--- a/archethic/reveal_secret.js
+++ b/archethic/reveal_secret.js
@@ -1,11 +1,7 @@
 import Archethic, { Crypto, Utils } from "archethic"
 import config from "./config.js"
 
-if (!config.endpoint || !config.userSeed) {
-  console.log("Invalid config !")
-  console.log("Config needs endpoint and userSeed")
-  process.exit(1)
-}
+const env = config.environments.local
 
 const args = []
 process.argv.forEach(function(val, index, _array) { if (index > 1) { args.push(val) } })
@@ -16,9 +12,12 @@ if (args.length != 2) {
   process.exit(1)
 }
 
-main(config.endpoint, config.userSeed)
+main()
 
-async function main(endpoint, seed) {
+async function main() {
+  const endpoint = env.endpoint
+  const seed = env.userSeed
+
   const htlcGenesisAddress = args[0]
   const secret = args[1]
 

--- a/evm/contracts/Pool/PoolBase.sol
+++ b/evm/contracts/Pool/PoolBase.sol
@@ -134,15 +134,16 @@ contract PoolBase is IPool, Initializable, OwnableUpgradeable {
             revert AlreadyProvisioned();
         }
 
-        bytes32 signatureHash = ECDSA.toEthSignedMessageHash(_hash);
-        address signer = ECDSA.recover(signatureHash, _v, _r, _s);
-
+        bytes32 messagePayloadHash = keccak256(abi.encodePacked(_hash, bytes32(block.chainid)));
+        bytes32 signedMessageHash = ECDSA.toEthSignedMessageHash(messagePayloadHash);
+        address signer = ECDSA.recover(signedMessageHash, _v, _r, _s);
         if (signer != archethicPoolSigner) {
             revert InvalidSignature();
         }
 
         delete signer;
-        delete signatureHash;
+        delete messagePayloadHash;
+        delete signedMessageHash;
 
         IHTLC htlcContract = _createSignedHTLC(_hash, _amount, _lockTime);
         _provisionedSwaps[_hash] = htlcContract;


### PR DESCRIPTION
This PR add integration of the chain's id in the EVM signature verification.

To support it on the Archethic side, the ETH signed message data must be derived from the keccak's hash of the concatenated binary: secret's hash + chain id (encoded in 256 bits) 