### PR TITLE
Add tool for refundable contracts

### DIFF
--- a/evm/contracts/Pool/PoolBase.sol
+++ b/evm/contracts/Pool/PoolBase.sol
@@ -11,7 +11,7 @@ import "../../interfaces/IHTLC.sol";
 
 using SafeMath for uint256; 
 
-contract PoolBase is IPool, Initializable, OwnableUpgradeable {
+abstract contract PoolBase is IPool, Initializable, OwnableUpgradeable {
 
     bool public locked;
     address public reserveAddress;
@@ -20,8 +20,11 @@ contract PoolBase is IPool, Initializable, OwnableUpgradeable {
     uint256 public poolCap;
     uint256 public safetyModuleFeeRate;
 
-    mapping(bytes32 => IHTLC) _provisionedSwaps;
-    mapping(bytes32 => IHTLC) _mintedSwaps;
+    mapping(bytes32 => IHTLC) _refProvisionedSwaps;
+    mapping(bytes32 => IHTLC) _refMintedSwaps;
+
+    address[] _provisionedSwaps;
+    address[] _mintedSwaps;
 
     event ReserveAddressChanged(address indexed _reservedAddress);
     event SafetyModuleAddressChanged(address indexed _safetyModuleAddress);
@@ -123,14 +126,18 @@ contract PoolBase is IPool, Initializable, OwnableUpgradeable {
         return _amount.mul(safetyModuleFeeRate).div(100000);
     }
 
-    function provisionedSwaps(bytes32 _hash) external view returns (IHTLC) {
-        return _provisionedSwaps[_hash];
+    function provisionedSwaps() external view returns (address[] memory) {
+        return _provisionedSwaps;
+    }
+
+    function provisionedSwap(bytes32 _hash) external view returns (IHTLC) {
+        return _refProvisionedSwaps[_hash];
     }
 
     function provisionHTLC(bytes32 _hash, uint256 _amount, uint _lockTime, bytes32 _r, bytes32 _s, uint8 _v) external {
         checkUnlocked();
 
-        if(address(_provisionedSwaps[_hash]) != address(0)) {
+        if(address(_refProvisionedSwaps[_hash]) != address(0)) {
             revert AlreadyProvisioned();
         }
 
@@ -145,12 +152,19 @@ contract PoolBase is IPool, Initializable, OwnableUpgradeable {
         delete signatureHash;
 
         IHTLC htlcContract = _createSignedHTLC(_hash, _amount, _lockTime);
-        _provisionedSwaps[_hash] = htlcContract;
+        _refProvisionedSwaps[_hash] = htlcContract;
+
+        _provisionedSwaps.push(address(htlcContract));
+
         emit ContractProvisioned(htlcContract, _amount);
     } 
 
-    function mintedSwaps(bytes32 _hash) external view returns (IHTLC) {
-        return _mintedSwaps[_hash];
+    function mintedSwaps() external view returns (address[] memory) {
+        return _mintedSwaps;
+    }
+
+    function mintedSwap(bytes32 _hash) external view returns (IHTLC) {
+        return _refMintedSwaps[_hash];
     }
 
     function mintHTLC(bytes32 _hash, uint256 _amount, uint _lockTime) payable virtual external {
@@ -158,11 +172,12 @@ contract PoolBase is IPool, Initializable, OwnableUpgradeable {
     }
 
     function _mintHTLC(bytes32 _hash, uint256 _amount, uint _lockTime) internal {
-        if(address(_mintedSwaps[_hash]) != address(0)) {
+        if(address(_refMintedSwaps[_hash]) != address(0)) {
             revert AlreadyMinted();
         }
         IHTLC htlcContract = _createChargeableHTLC(_hash, _amount, _lockTime);
-        _mintedSwaps[_hash] = htlcContract;
+        _refMintedSwaps[_hash] = htlcContract;
+        _mintedSwaps.push(address(htlcContract));
         emit ContractMinted(htlcContract, _amount);
     }
 

--- a/evm/interfaces/IPool.sol
+++ b/evm/interfaces/IPool.sol
@@ -21,7 +21,9 @@ interface IPool {
     function safetyModuleFeeRate() external returns(uint256);
     function poolCap() external returns(uint256);
     function locked() external returns(bool);
+    function provisionedSwaps() external returns (address[] memory);
+    function mintedSwaps() external returns (address[] memory);
 
-    function provisionedSwaps(bytes32 _hash) external returns (IHTLC);
-    function mintedSwaps(bytes32 _hash) external returns (IHTLC);
+    function provisionedSwap(bytes32 _hash) external returns (IHTLC);
+    function mintedSwap(bytes32 _hash) external returns (IHTLC);
 }

--- a/evm/refundable_contracts.js
+++ b/evm/refundable_contracts.js
@@ -1,0 +1,65 @@
+const { ethers, toNumber } = require("ethers")
+
+let args = []
+process.argv.forEach(function (val, index, array) {
+    if (index > 1) {
+        args.push(val)
+    }
+});
+
+if (args.length != 1) {
+    console.log("Invalid arguments")
+    console.log("Usage: node refundable_contracts.js [pool address as 0x......]")
+    return
+}
+
+const poolAddress = args[0]
+
+if(! /^0x[0-9a-fA-F]+$/.test(poolAddress)) {
+    console.log("Pool address must be like 0x...")
+    return;
+}
+
+const PROVIDER_URL = process.env["PROVIDER_URL"] || "http://127.0.0.1:7545"
+const provider = new ethers.JsonRpcProvider(PROVIDER_URL)
+
+const poolABI = [
+    "function provisionedSwaps() view returns (address[] memory)"
+]
+
+const poolContract = new ethers.Contract(poolAddress, poolABI, provider);
+
+poolContract.provisionedSwaps().then(async swaps => {
+
+    const HTLC_ABI = [
+        "function finished() view returns(bool)",
+        "function startTime() view returns(uint256)",
+        "function lockTime() view returns(uint256)"
+    ]
+
+    let htlcToRefund = []
+
+    for (let i = 0; i < swaps.length; i++) {
+        const swapAddress = swaps[i];
+
+        const htlcContract = new ethers.Contract(swapAddress, HTLC_ABI, provider);
+
+        const finished = await htlcContract.finished()
+        const startTime = await htlcContract.startTime()
+        const lockTime = await htlcContract.lockTime()
+
+        const lockDate = new Date((toNumber(startTime) + toNumber(lockTime)) * 1000)
+        const currentDate = new Date()
+
+        if (!finished && lockDate.getTime() < currentDate.getTime()) {
+            htlcToRefund.push(swapAddress)
+        }
+    }
+
+    console.log("--------------------------")
+    console.log("List of contracts to refund:")
+    console.log("--------------------------")
+    for (let i = 0; i < htlcToRefund.length; i++) {
+        console.log("- ", htlcToRefund[i]);
+    }
+})

--- a/evm/test/Pool/ERCPool.js
+++ b/evm/test/Pool/ERCPool.js
@@ -128,7 +128,7 @@ contract("ERC LiquidityPool", (accounts) => {
         const { r, s, v } = createEthSign(sigHash, archPoolSigner.privateKey)
 
         await instance.provisionHTLC("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", web3.utils.toWei('1'), 60, `0x${r}`, `0x${s}`, v)
-        const htlcAddress = await instance.provisionedSwaps("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const htlcAddress = await instance.provisionedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
         const balanceHTLC = await DummyTokenInstance.balanceOf(htlcAddress)
         assert.equal(web3.utils.toWei('1'), balanceHTLC)
 
@@ -198,7 +198,7 @@ contract("ERC LiquidityPool", (accounts) => {
             .digest("hex")
 
         await instance.mintHTLC(`0x${secretHash}`, web3.utils.toWei('1'), 60)
-        const htlcAddress = await instance.mintedSwaps(`0x${secretHash}`)
+        const htlcAddress = await instance.mintedSwap(`0x${secretHash}`)
         const HTLCInstance = await ChargeableHTLC.at(htlcAddress)
         assert.equal(await HTLCInstance.safetyModuleAddress(), satefyModuleAddress)
         assert.equal(await HTLCInstance.hash(), `0x${secretHash}`)

--- a/evm/test/Pool/ETHPool.js
+++ b/evm/test/Pool/ETHPool.js
@@ -112,7 +112,7 @@ contract("ETH LiquidityPool", (accounts) => {
         const { r, s, v } = createEthSign(sigHash, archPoolSigner.privateKey)
 
         await instance.provisionHTLC("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", web3.utils.toWei('1'), 60, `0x${r}`, `0x${s}`, v)
-        const htlcAddress = await instance.provisionedSwaps("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const htlcAddress = await instance.provisionedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
         const balanceHTLC = await web3.eth.getBalance(htlcAddress)
         assert.equal(web3.utils.toWei('1'), balanceHTLC)
 
@@ -193,7 +193,7 @@ contract("ETH LiquidityPool", (accounts) => {
         await instance.unlock()
 
         await instance.mintHTLC("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", web3.utils.toWei('1'), 60, { value: web3.utils.toWei('1') })
-        const htlcAddress = await instance.mintedSwaps("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const htlcAddress = await instance.mintedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
         const HTLCInstance = await ChargeableHTLC.at(htlcAddress)
         assert.equal(await HTLCInstance.safetyModuleAddress(), safetyModuleAddress)
         assert.equal(await HTLCInstance.hash(), "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")

--- a/evm/test/Proxy.js
+++ b/evm/test/Proxy.js
@@ -36,7 +36,7 @@ contract("LP Proxy", (accounts) => {
         const proxiedPoolInstance = await deployProxy(LiquidityPool, [reserveAddress, satefyModuleAddress, 5, archPoolSigner.address, web3.utils.toWei('200')]);
 
         await proxiedPoolInstance.mintHTLC("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", web3.utils.toWei('1'), 60, { value: web3.utils.toWei('1') })
-        const htlcAddress = await proxiedPoolInstance.mintedSwaps("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const htlcAddress = await proxiedPoolInstance.mintedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
         const HTLCInstance = await ChargeableHTLC.at(htlcAddress)
 
         assert.equal(await HTLCInstance.from(), proxiedPoolInstance.address)
@@ -62,7 +62,7 @@ contract("LP Proxy", (accounts) => {
         const { r, s, v } = createEthSign(sigHash, archPoolSigner.privateKey)
 
         await proxiedPoolInstance.provisionHTLC("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", web3.utils.toWei('1'), 60, `0x${r}`, `0x${s}`, v)
-        const htlcAddress = await proxiedPoolInstance.provisionedSwaps("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const htlcAddress = await proxiedPoolInstance.provisionedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
         const balanceHTLC = await web3.eth.getBalance(htlcAddress)
         assert.equal(web3.utils.toWei('1'), balanceHTLC)
 


### PR DESCRIPTION
This PR introduces a new change in the contract to ease the identification of provisioned swaps to be able to list the refundable contracts based on the state of the HTLC.

This PR adds a new tool to be able to check the refundable contracts based on a pool address.
This can be used as `node refundable_contracts.js POOL_ADDRESS`. It will return the list of refundable contracts.
By default it's connecting on `localhost:7545`, to customize the JsonRPC endpoint, you have to specify the env var: `PROVIDER_URL=XXX` as in `PROVIDER_URL=XXX node refundable_contracts.js POOL_ADDRESS`
