### PR TITLE
AE pool receive request_secret from user

### DIFF
--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -90,6 +90,16 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
     Contract.set_code ""
   end
 
+  condition triggered_by: transaction, on: refund(), as: [
+    timestamp: timestamp >= #{end_time}
+  ]
+
+  actions triggered_by: transaction, on: refund() do
+    Contract.set_type "transfer"
+    #{return_transfer_code}
+    Contract.set_code ""
+  end
+
   condition triggered_by: transaction, on: reveal_secret(secret), as: [
     timestamp: transaction.timestamp < #{end_time},
     content: Crypto.hash(String.to_hex(secret)) == 0x#{secret_hash},
@@ -223,6 +233,7 @@ export fun get_signed_htlc(user_address, pool_address, token, amount) do
 
   """
   @version 1
+
   condition triggered_by: transaction, on: set_secret_hash(_secret_hash, _secret_hash_signature, _end_time), as: [
     previous_public_key: (
 		  # Transaction is not yet validated so we need to use previous address

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -36,19 +36,34 @@ end
 # Archethic => EVM : Request secret hash #
 ##########################################
 
-condition triggered_by: transaction, on: request_secret_hash(amount, user_address, chain_id), as: [
-  type: "contract",
-  code: valid_signed_code?(amount, user_address),
+condition triggered_by: transaction, on: request_secret_hash(htlc_genesis_address, amount, user_address, chain_id), as: [
+  type: "transfer",
+  code: valid_signed_code?(htlc_genesis_address, amount, user_address),
   previous_public_key: (
     # Ensure contract has enough fund to withdraw
     previous_address = Chain.get_previous_address()
     balance = Chain.get_token_balance(previous_address, #TOKEN_ADDRESS#)
     balance >= amount
   ),
-  content: List.in?([#CHAIN_IDS#], chain_id)
+  content: List.in?([#CHAIN_IDS#], chain_id),
+  token_transfers: (
+    valid? = false
+
+    htlc_genesis_address = String.to_hex(htlc_genesis_address)
+    transfers = Map.get(transaction.token_transfers, htlc_genesis_address, [])
+    for transfer in transfers do
+      if transfer.token_address == #TOKEN_ADDRESS# &&
+         transfer.token_id == 0 &&
+         transfer.amount == amount do
+        valid? = true   
+     end
+    end
+
+    valid?
+  )
 ]
 
-actions triggered_by: transaction, on: request_secret_hash(_amount, _user_address, chain_id) do
+actions triggered_by: transaction, on: request_secret_hash(htlc_genesis_address, _amount, _user_address, chain_id) do
   # Here delete old secret that hasn't been used before endTime
   contract_content = Contract.call_function(#STATE_ADDRESS#, "get_state", [])
 
@@ -76,12 +91,11 @@ actions triggered_by: transaction, on: request_secret_hash(_amount, _user_addres
     chain_id: chain_id
   ]
 
-  htlc_genesis_address = Chain.get_genesis_address(transaction.address)
-
+  htlc_genesis_address = String.to_hex(htlc_genesis_address)
   contract_content = Map.set(contract_content, htlc_genesis_address, htlc_map)
 
   Contract.add_recipient address: #STATE_ADDRESS#, action: "update_state", args: [contract_content]
-  Contract.add_recipient address: transaction.address, action: "set_secret_hash", args: [secret_hash, signature, end_time]
+  Contract.add_recipient address: htlc_genesis_address, action: "set_secret_hash", args: [secret_hash, signature, end_time]
 end
 
 ####################################
@@ -177,17 +191,26 @@ fun valid_chargeable_code?(end_time, amount, user_address, secret_hash) do
   Code.is_same?(expected_code, transaction.code)
 end
 
-fun valid_signed_code?(amount, user_address) do
-  args = [
-    user_address,
-    #POOL_ADDRESS#,
-    #TOKEN_ADDRESS#,
-    amount
-  ]
+fun valid_signed_code?(htlc_address, amount, user_address) do
+  valid? = false
 
-  expected_code = Contract.call_function(#FACTORY_ADDRESS#, "get_signed_htlc", args)
+  htlc_address = String.to_hex(htlc_address)
+  last_htlc_transaction = Chain.get_last_transaction(htlc_address)
 
-  Code.is_same?(expected_code, transaction.code)
+  if last_htlc_transaction != nil do
+    args = [
+      user_address,
+      #POOL_ADDRESS#,
+      #TOKEN_ADDRESS#,
+      amount
+    ]
+
+    expected_code = Contract.call_function(#FACTORY_ADDRESS#, "get_signed_htlc", args)
+
+    valid? = Code.is_same?(expected_code, last_htlc_transaction.code)
+  end
+
+  valid?
 end
 
 fun sign_for_evm(data, chain_id) do

--- a/archethic/request_secret.js
+++ b/archethic/request_secret.js
@@ -8,7 +8,7 @@ process.argv.forEach(function(val, index, _array) { if (index > 1) { args.push(v
 
 if (args.length != 2) {
   console.log("Missing arguments")
-  console.log("Usage: node deploy_htlc.js [poolAddress] [htlcGenesisAddress]")
+  console.log("Usage: node deploy_htlc.js [tokenSymbol] [htlcGenesisAddress]")
   process.exit(1)
 }
 
@@ -18,8 +18,11 @@ async function main() {
   const endpoint = env.endpoint
   const seed = env.userSeed
 
-  const poolGenesisAddress = args[0]
+  const token = args[0]
   const htlcGenesisAddress = args[1]
+
+  const poolSeed = Crypto.hash(token).slice(1)
+  const poolGenesisAddress = Utils.uint8ArrayToHex(Crypto.deriveAddress(poolSeed, 0))
 
   const archethic = new Archethic(endpoint)
   await archethic.connect()

--- a/evm/migrations/2_deploy_eth_pool.js
+++ b/evm/migrations/2_deploy_eth_pool.js
@@ -10,7 +10,7 @@ module.exports = async function (deployer, network, accounts) {
     if (network == "development") {
         reserveAddress = accounts[4]
         safetyModuleAddress = accounts[5]
-        archethicPoolSigner = '0x3f6e4b7cde77901603425009c4a65177270156b2'
+        archethicPoolSigner = '0x480b332bf0cb7b6f225b06a16ea2a27c74379f9d'
         poolCap = web3.utils.toWei('200')
     }
 


### PR DESCRIPTION
New workflow for provisionning HTLC contract on Archethic side:
**Before:**
HTLC contract creation also requested pool to create a secret. But since the pool ensure the contract has enough fund, it means that the user should provision the HTLC contract before it's creation.
**Now:**
The HTLC contract has to be created without triggering the pool to create a secret. Then the user should create a transaction with both actions:
- provision the HTLC contract with a transfer of the expected token / amount
- request the pool to generate a secret for the HTLC

new params:
- The action `request_funds` of the pool now takes a new argument which is the htlc contract genesis address `request_funds(htlcGenesisAddress, amount, userAddress, chainId)`