### PR TITLE
Manual refund + update code

### DIFF
--- a/archethic/config.js
+++ b/archethic/config.js
@@ -6,6 +6,7 @@ export default {
       defaultChainId: 1337,
       factorySeed: "factory",
       userSeed: "user",
+      masterSeed: "master",
       // Genesis address of seed "protocolFee"
       protocolFeeAddress: "000001F449ABE3971623E30C10DA5E692DFCF9C795E4E0BC66BCD130F3FC5553552E"
     }

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -130,6 +130,25 @@ actions triggered_by: transaction, on: reveal_secret(htlc_genesis_address) do
   Contract.add_recipient address: htlc_genesis_address, action: "reveal_secret", args: [secret, signature]
 end
 
+condition triggered_by: transaction, on: update_code(new_code), as: [
+  previous_public_key: (
+		# Pool code can only be updated from the master chain if the bridge
+
+		# Transaction is not yet validated so we need to use previous address
+		# to get the genesis address
+		previous_address = Chain.get_previous_address()
+		Chain.get_genesis_address(previous_address) == #MASTER_GENESIS_ADDRESS#
+	),
+	code: Code.is_valid?(new_code)
+]
+
+actions triggered_by: transaction, on: update_code(new_code) do
+  Contract.set_type "contract"
+  # Keep contract state
+  Contract.set_content contract.content
+  Contract.set_code new_code
+end
+
 ####################
 # Public functions #
 ####################

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -132,6 +132,25 @@ actions triggered_by: transaction, on: reveal_secret(htlc_genesis_address) do
   Contract.add_recipient address: htlc_genesis_address, action: "reveal_secret", args: [secret, signature]
 end
 
+condition triggered_by: transaction, on: update_code(new_code), as: [
+  previous_public_key: (
+		# Pool code can only be updated from the master chain if the bridge
+
+		# Transaction is not yet validated so we need to use previous address
+		# to get the genesis address
+		previous_address = Chain.get_previous_address()
+		Chain.get_genesis_address(previous_address) == #MASTER_GENESIS_ADDRESS#
+	),
+	code: Code.is_valid?(new_code)
+]
+
+actions triggered_by: transaction, on: update_code(new_code) do
+  Contract.set_type "contract"
+  # Keep contract state
+  Contract.set_content contract.content
+  Contract.set_code new_code
+end
+
 ####################
 # Public functions #
 ####################


### PR DESCRIPTION
This PR adds 2 new functionnalities:
- Manual refund of the HTLC contract, in case of the datetime execution fail for some reason, the same code wan be triggered through a trigger transaction on action refund
- Code update, the pool code can be updated with an action `update_code(new_code)`. This action can be triggered only if the transaction comes from the "Master chain" of the bridge