### PR TITLE
Add signature for signed htlc refund

### DIFF
--- a/archethic/bridge.js
+++ b/archethic/bridge.js
@@ -1,38 +1,40 @@
 #!/usr/bin/env node
 
-import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
-import deploy_pool from './commands/pool_management/deploy_pool.js'
-import deploy_factory from './commands/pool_management/deploy_factory.js'
-import update_pool from './commands/pool_management/update_pool.js'
-import init_keychain from './commands/pool_management/init_keychain.js'
-import derive_eth_address from './commands/pool_management/derive_eth_address.js'
+import deploy_pool from "./commands/pool_management/deploy_pool.js";
+import deploy_factory from "./commands/pool_management/deploy_factory.js";
+import update_pool from "./commands/pool_management/update_pool.js";
+import init_keychain from "./commands/pool_management/init_keychain.js";
+import derive_eth_address from "./commands/pool_management/derive_eth_address.js";
 
-import deploy_chargeable_htlc from './commands/test/deploy_chargeable_htlc.js'
-import deploy_signed_htlc from './commands/test/deploy_signed_htlc.js'
-import reveal_secret from './commands/test/reveal_secret.js'
-import provision_htlc from './commands/test/provision_htlc.js'
-import request_secret from './commands/test/request_secret.js'
+import deploy_chargeable_htlc from "./commands/test/deploy_chargeable_htlc.js";
+import deploy_signed_htlc from "./commands/test/deploy_signed_htlc.js";
+import reveal_secret from "./commands/test/reveal_secret.js";
+import provision_htlc from "./commands/test/provision_htlc.js";
+import request_secret from "./commands/test/request_secret.js";
 
-import analytics from './commands/analytics/analytics.js'
-import refund from './commands/test/refund.js'
+import analytics from "./commands/analytics/analytics.js";
+import pool_refund from "./commands/test/pool_refund.js";
+import refund_chargeable from "./commands/test/refund_chargeable.js";
 
-const y = yargs(hideBin(process.argv))
+const y = yargs(hideBin(process.argv));
 
-y.command(deploy_pool).help()
-y.command(deploy_factory).help()
-y.command(update_pool).help()
-y.command(init_keychain).help()
-y.command(derive_eth_address).help()
+y.command(deploy_pool).help();
+y.command(deploy_factory).help();
+y.command(update_pool).help();
+y.command(init_keychain).help();
+y.command(derive_eth_address).help();
 
-y.command(deploy_chargeable_htlc).help()
-y.command(deploy_signed_htlc).help()
-y.command(reveal_secret).help()
-y.command(provision_htlc).help()
-y.command(request_secret).help()
-y.command(refund).help()
+y.command(deploy_chargeable_htlc).help();
+y.command(deploy_signed_htlc).help();
+y.command(reveal_secret).help();
+y.command(provision_htlc).help();
+y.command(request_secret).help();
+y.command(pool_refund).help();
+y.command(refund_chargeable).help();
 
-y.command(analytics).help()
+y.command(analytics).help();
 
-y.parse()
+y.parse();

--- a/archethic/bridge.js
+++ b/archethic/bridge.js
@@ -16,6 +16,7 @@ import provision_htlc from './commands/test/provision_htlc.js'
 import request_secret from './commands/test/request_secret.js'
 
 import analytics from './commands/analytics/analytics.js'
+import refund from './commands/test/refund.js'
 
 const y = yargs(hideBin(process.argv))
 
@@ -30,6 +31,7 @@ y.command(deploy_signed_htlc).help()
 y.command(reveal_secret).help()
 y.command(provision_htlc).help()
 y.command(request_secret).help()
+y.command(refund).help()
 
 y.command(analytics).help()
 

--- a/archethic/commands/test/pool_refund.js
+++ b/archethic/commands/test/pool_refund.js
@@ -2,7 +2,7 @@ import Archethic, { Utils } from "@archethicjs/sdk"
 import config from "../../config.js"
 import { getGenesisAddress, getPoolServiceName, getServiceGenesisAddress } from "../utils.js"
 
-const command = "refund"
+const command = "pool_refund"
 const describe = "Request a pool to refund a signed htlc"
 const builder = {
   token: {

--- a/archethic/commands/test/refund.js
+++ b/archethic/commands/test/refund.js
@@ -1,0 +1,120 @@
+import Archethic, { Utils } from "@archethicjs/sdk"
+import config from "../../config.js"
+import { getGenesisAddress, getPoolServiceName, getServiceGenesisAddress } from "../utils.js"
+
+const command = "refund"
+const describe = "Request a pool to refund a signed htlc"
+const builder = {
+  token: {
+    describe: "The token of the pool (used to retrieve pool address)",
+    demandOption: true, // Required
+    type: "string"
+  },
+  htlc_address: {
+    describe: "The genesis address of the HTLC contract",
+    demandOption: true,
+    type: "string"
+  },
+  access_seed: {
+    describe: "the keychain access seed (default in env config)",
+    demandOption: false,
+    type: "string"
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string"
+  }
+}
+
+const handler = async function(argv) {
+  const envName = argv["env"] ? argv["env"] : "local"
+  const env = config.environments[envName]
+
+  const keychainAccessSeed = argv["access_seed"] ? argv["access_seed"] : env.keychainAccessSeed
+
+  if (keychainAccessSeed == undefined) {
+    console.log("Keychain access seed not defined")
+    process.exit(1)
+  }
+
+  const archethic = new Archethic(env.endpoint)
+  await archethic.connect()
+
+  let keychain
+
+  try {
+    keychain = await archethic.account.getKeychain(keychainAccessSeed)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const token = argv["token"]
+  const htlcGenesisAddress = argv["htlc_address"]
+
+  const serviceName = getPoolServiceName(token)
+  const poolGenesisAddress = getServiceGenesisAddress(keychain, serviceName)
+
+  const htlcAddressBefore = await getLastAddress(archethic, htlcGenesisAddress)
+
+  const genesisAddress = getGenesisAddress(env.userSeed)
+  console.log("User genesis address:", genesisAddress)
+  const index = await archethic.transaction.getTransactionIndex(genesisAddress)
+
+  const tx = archethic.transaction.new()
+    .setType("transfer")
+    .addRecipient(poolGenesisAddress, "refund", [htlcGenesisAddress])
+    .build(env.userSeed, index)
+    .originSign(Utils.originPrivateKey)
+
+  tx.on("requiredConfirmation", (_confirmations) => {
+    console.log("Refund request successfully sent !")
+    console.log("Waiting for HTLC to refund ...")
+    wait(htlcAddressBefore, htlcGenesisAddress, env.endpoint, archethic)
+  }).on("error", (context, reason) => {
+    console.log("Error while sending transaction")
+    console.log("Contest:", context)
+    console.log("Reason:", reason)
+    process.exit(1)
+  }).send(50)
+}
+
+async function getLastAddress(archethic, address) {
+  return new Promise(async (resolve, reject) => {
+
+    const query = `
+    {
+      lastTransaction(address: "${address}") {
+        address
+      }
+    }
+    `
+
+    archethic.network.rawGraphQLQuery(query)
+      .then(res => resolve(res.lastTransaction.address))
+      .catch(err => reject(err))
+  })
+}
+
+async function wait(htlcAddressBefore, htlcGenesisAddress, endpoint, archethic, i = 0) {
+  const htlcAddressAfter = await getLastAddress(archethic, htlcGenesisAddress)
+  if (i == 5) {
+    console.log("HTLC didn't refund")
+    process.exit(1)
+  } else if (htlcAddressBefore == htlcAddressAfter) {
+    setTimeout(() => wait(htlcAddressBefore, htlcGenesisAddress, endpoint, archethic, i + 1), 500)
+  } else {
+    console.log("HTLC succesfully refunded !")
+    console.log("Address:", htlcAddressAfter)
+    console.log(endpoint + "/explorer/transaction/" + htlcAddressAfter)
+    process.exit(0)
+  }
+}
+
+export default {
+  command,
+  describe,
+  builder,
+  handler
+}

--- a/archethic/commands/test/refund_chargeable.js
+++ b/archethic/commands/test/refund_chargeable.js
@@ -1,0 +1,111 @@
+import Archethic, { Utils } from "@archethicjs/sdk";
+import config from "../../config.js";
+import { getGenesisAddress } from "../utils.js";
+
+const command = "refund_chargeable";
+const describe = "Request a Chargeable HTLC to refund";
+const builder = {
+  htlc_address: {
+    describe: "The genesis address of the HTLC contract",
+    demandOption: true,
+    type: "string",
+  },
+  evm_contract: {
+    describe: "The HTLC EVM contract address",
+    demandOption: true,
+    type: "string",
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string",
+  },
+};
+
+const handler = async function (argv) {
+  const envName = argv["env"] ? argv["env"] : "local";
+  const env = config.environments[envName];
+
+  const htlcAddress = argv["htlc_address"];
+  const evm_contract = argv["evm_contract"];
+
+  const archethic = new Archethic(env.endpoint);
+  await archethic.connect();
+
+  const htlcAddressBefore = await getLastAddress(archethic, htlcAddress);
+
+  const genesisAddress = getGenesisAddress(env.userSeed);
+  console.log("User genesis address:", genesisAddress);
+  const index = await archethic.transaction.getTransactionIndex(genesisAddress);
+
+  // Get faucet before sending transaction
+  // await requestFaucet(env.endpoint, poolGenesisAddress)
+
+  const tx = archethic.transaction
+    .new()
+    .setType("transfer")
+    .addRecipient(htlcAddress, "refund", [evm_contract])
+    .build(env.userSeed, index)
+    .originSign(Utils.originPrivateKey);
+
+  tx.on("requiredConfirmation", (_confirmations) => {
+    console.log("Secret successfully sent !");
+    console.log("Waiting for HTLC to refund ...");
+    wait(htlcAddressBefore, htlcAddress, env.endpoint, archethic);
+  })
+    .on("error", (context, reason) => {
+      console.log("Error while sending transaction");
+      console.log("Contest:", context);
+      console.log("Reason:", reason);
+      process.exit(1);
+    })
+    .send(50);
+};
+
+async function getLastAddress(archethic, address) {
+  return new Promise(async (resolve, reject) => {
+    const query = `
+    {
+      lastTransaction(address: "${address}") {
+        address
+      }
+    }
+    `;
+
+    archethic.network
+      .rawGraphQLQuery(query)
+      .then((res) => resolve(res.lastTransaction.address))
+      .catch((err) => reject(err));
+  });
+}
+
+async function wait(
+  htlcAddressBefore,
+  htlcAddress,
+  endpoint,
+  archethic,
+  i = 0,
+) {
+  const htlcAddressAfter = await getLastAddress(archethic, htlcAddress);
+  if (i == 5) {
+    console.log("HTLC didn't refund");
+    process.exit(1);
+  } else if (htlcAddressBefore == htlcAddressAfter) {
+    setTimeout(
+      () => wait(htlcAddressBefore, htlcAddress, endpoint, archethic, i + 1),
+      500,
+    );
+  } else {
+    console.log("HTLC succesfully refunded !");
+    console.log("Address:", htlcAddressAfter);
+    console.log(endpoint + "/explorer/transaction/" + htlcAddressAfter);
+    process.exit(0);
+  }
+}
+
+export default {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -264,6 +264,10 @@ export fun get_signed_htlc(user_address, pool_address, token, amount) do
     end
 
     condition triggered_by: transaction, on: refund(secret, secret_signature), as: [
+      previous_public_key: (
+        previous_address = Chain.get_previous_address()
+        Chain.get_genesis_address(previous_address) == 0x#{pool_address}
+      ),
       timestamp: timestamp >= \#{end_time}
     ]
 

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -94,7 +94,7 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
       Contract.set_code ""
     end
 
-    condition triggered_by: transaction, on: refund(evm_contract), as: [
+    condition triggered_by: transaction, on: refund(), as: [
       content: (
         valid? = false
 
@@ -121,7 +121,7 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
       )
     ]
 
-    actions triggered_by: transaction, on: refund(evm_tx_address) do
+    actions triggered_by: transaction, on: refund() do
       Contract.set_type "transfer"
       #{return_transfer_code}
       Contract.set_code ""

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -586,8 +586,8 @@ end
 
 fun sign_for_evm_refund(data) do
   # Perform a first hash to combine data and "refund"
-  abi_data = Evm.abi_encode("(bytes32,string)", [data, "refund"])
-  hash = Crypto.hash(abi_data, "keccak256")
+  sig_payload = "#{data}#{String.to_hex("refund")}"
+  hash = Crypto.hash(sig_payload, "keccak256")
 
   prefix = String.to_hex("\x19Ethereum Signed Message:\n32")
   signature_payload = Crypto.hash("#{prefix}#{hash}", "keccak256")

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -281,7 +281,7 @@ condition triggered_by: transaction, on: refund(htlc_genesis_address), as: [
     htlc_map = Map.get(requested_secrets, htlc_genesis_address)
 
     if htlc_map != nil do
-      valid? = htlc_map.end_time < Time.now()
+      valid? = htlc_map.end_time <= Time.now()
     end
 
     valid?

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -551,8 +551,8 @@ end
 
 fun sign_for_evm_refund(data) do
   # Perform a first hash to combine data and "refund"
-  abi_data = Evm.abi_encode("(bytes32,string)", [data, "refund"])
-  hash = Crypto.hash(abi_data, "keccak256")
+  sig_payload = "#{data}#{String.to_hex("refund")}"
+  hash = Crypto.hash(sig_payload, "keccak256")
 
   prefix = String.to_hex("\x19Ethereum Signed Message:\n32")
   signature_payload = Crypto.hash("#{prefix}#{hash}", "keccak256")

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -268,6 +268,46 @@ actions triggered_by: transaction, on: reveal_secret(htlc_genesis_address, _evm_
   )
 end
 
+condition triggered_by: transaction, on: refund(htlc_genesis_address), as: [
+  content: (
+    # Ensure htlc_genesis_address exists in pool state
+    # and end_time has not been reached
+    valid? = false
+
+    contract_content = Json.parse(contract.content)
+
+    htlc_genesis_address = String.to_hex(htlc_genesis_address)
+    requested_secrets = Map.get(contract_content, "requested_secrets", Map.new())
+    htlc_map = Map.get(requested_secrets, htlc_genesis_address)
+
+    if htlc_map != nil do
+      valid? = htlc_map.end_time < Time.now()
+    end
+
+    valid?
+  )
+]
+
+actions triggered_by: transaction, on: refund(htlc_genesis_address) do
+  contract_content = Json.parse(contract.content)
+  requested_secrets = Map.get(contract_content, "requested_secrets", Map.new())
+  htlc_genesis_address = String.to_hex(htlc_genesis_address)
+  htlc_map = Map.get(requested_secrets, htlc_genesis_address)
+
+  secret = Crypto.hmac(htlc_map.hmac_address)
+  signature = sign_for_evm_refund(secret)
+
+  requested_secrets = Map.delete(requested_secrets, htlc_genesis_address)
+  contract_content = Map.set(contract_content, "requested_secrets", requested_secrets)
+  Contract.set_content(Json.to_string(contract_content))
+
+  Contract.add_recipient(
+    address: htlc_genesis_address,
+    action: "refund",
+    args: [secret, signature]
+  )
+end
+
 condition triggered_by: transaction, on: update_code(new_code), as: [
   previous_public_key:
     (
@@ -493,6 +533,26 @@ fun sign_for_evm(data, chain_id) do
     abi_data = Evm.abi_encode("(bytes32,uint)", [data, chain_id])
     hash = Crypto.hash(abi_data, "keccak256")
   end
+
+  prefix = String.to_hex("\x19Ethereum Signed Message:\n32")
+  signature_payload = Crypto.hash("#{prefix}#{hash}", "keccak256")
+
+  sig = Crypto.sign_with_recovery(signature_payload)
+
+  if sig.v == 0 do
+    sig = Map.set(sig, "v", 27)
+  else
+    sig = Map.set(sig, "v", 28)
+  end
+
+  sig
+end
+
+
+fun sign_for_evm_refund(data) do
+  # Perform a first hash to combine data and "refund"
+  abi_data = Evm.abi_encode("(bytes32,string)", [data, "refund"])
+  hash = Crypto.hash(abi_data, "keccak256")
 
   prefix = String.to_hex("\x19Ethereum Signed Message:\n32")
   signature_payload = Crypto.hash("#{prefix}#{hash}", "keccak256")

--- a/evm/contracts/HTLC/ChargeableHTLC_ERC.sol
+++ b/evm/contracts/HTLC/ChargeableHTLC_ERC.sol
@@ -56,7 +56,7 @@ contract ChargeableHTLC_ERC is HTLC_ERC {
     }
 
     /// @dev Send ERC20 to the HTLC's recipient and safety module fee
-    function _transfer() internal override {
+    function _transferAsWithdraw() internal override {
         IERC20 _token = token;
 
         uint _fee = fee;
@@ -96,8 +96,8 @@ contract ChargeableHTLC_ERC is HTLC_ERC {
     }
 
     /// @dev Send back ERC20 (amount + fee) to the HTLC's creator
-    function _refund() internal override {
-        SafeERC20.safeTransfer(token, from, (amount + fee));
+    function _transferAsRefund() internal override {
+        SafeERC20.safeTransfer(token, from, amount + fee);
     }
 
     function withdraw(bytes32 _secret, bytes32 _r, bytes32 _s, uint8 _v) external {

--- a/evm/contracts/HTLC/ChargeableHTLC_ETH.sol
+++ b/evm/contracts/HTLC/ChargeableHTLC_ETH.sol
@@ -59,7 +59,7 @@ contract ChargeableHTLC_ETH is HTLC_ETH {
     }
 
     /// @dev Send ethers to the HTLC's recipient and safety module fee
-    function _transfer() internal override {
+    function _transferAsWithdraw() internal override {
         bool sent = false;
         uint _fee = fee;
         address _refillAddress = refillAddress;
@@ -101,7 +101,7 @@ contract ChargeableHTLC_ETH is HTLC_ETH {
     }
 
     /// @dev Send back ethers (amount + fee) to the HTLC's creator
-    function _refund() internal override {
+    function _transferAsRefund() internal override {
         (bool sent, ) = from.call{value: amount + fee}("");
         require(sent, "ETH transfer failed - refund");
     }

--- a/evm/contracts/HTLC/HTLCBase.sol
+++ b/evm/contracts/HTLC/HTLCBase.sol
@@ -91,6 +91,9 @@ abstract contract HTLCBase is IHTLC {
     /// @dev It raises if the HTLC doesn't have enough funds
     /// @dev It raises if it's called after the locktime
     function withdraw(bytes32 _secret) virtual external {
+        if (!_beforeLockTime(block.timestamp)) {
+            revert TooLate();
+        }
         _withdraw(_secret);
     }
 
@@ -104,9 +107,7 @@ abstract contract HTLCBase is IHTLC {
         if (!_enoughFunds()) {
             revert InsufficientFunds();
         }
-        if (!_beforeLockTime(block.timestamp)) {
-            revert TooLate();
-        }
+
         secret = _secret;
         _transferAsWithdraw();
         status = HTLCStatus.WITHDRAWN;
@@ -124,6 +125,9 @@ abstract contract HTLCBase is IHTLC {
     /// @dev It raises if the HTLC doesn't have enough funds
     /// @dev It raises if it's called before the locktime
     function refund() virtual external {
+        if (_beforeLockTime(block.timestamp)) {
+             revert TooEarly();
+        }
         _refund();
     }
 
@@ -134,9 +138,7 @@ abstract contract HTLCBase is IHTLC {
         if (!_enoughFunds()) {
             revert InsufficientFunds();
         }
-        if (_beforeLockTime(block.timestamp)) {
-            revert TooEarly();
-        }
+
         _transferAsRefund();
         status = HTLCStatus.REFUNDED;
         emit Refunded();

--- a/evm/contracts/HTLC/HTLCBase.sol
+++ b/evm/contracts/HTLC/HTLCBase.sol
@@ -108,7 +108,7 @@ abstract contract HTLCBase is IHTLC {
             revert TooLate();
         }
         secret = _secret;
-        _transfer();
+        _transferAsWithdraw();
         status = HTLCStatus.WITHDRAWN;
         emit Withdrawn();
     }
@@ -123,7 +123,11 @@ abstract contract HTLCBase is IHTLC {
     /// @dev It raises if the HTLC has already been withdrawn or refunded
     /// @dev It raises if the HTLC doesn't have enough funds
     /// @dev It raises if it's called before the locktime
-    function refund() external {
+    function refund() virtual external {
+        _refund();
+    }
+
+    function _refund() internal {
         if (status != HTLCStatus.PENDING) {
             revert AlreadyRefunded();
         }
@@ -133,7 +137,7 @@ abstract contract HTLCBase is IHTLC {
         if (_beforeLockTime(block.timestamp)) {
             revert TooEarly();
         }
-        _refund();
+        _transferAsRefund();
         status = HTLCStatus.REFUNDED;
         emit Refunded();
     }
@@ -142,8 +146,8 @@ abstract contract HTLCBase is IHTLC {
         return timestamp < lockTime;
     }
 
-    function _transfer() virtual internal{}
-    function _refund() virtual internal{}
+    function _transferAsWithdraw() virtual internal{}
+    function _transferAsRefund() virtual internal{}
     function _enoughFunds() virtual internal view returns (bool) {}
 
     function enoughFunds() external view returns (bool) {

--- a/evm/contracts/HTLC/HTLC_ERC.sol
+++ b/evm/contracts/HTLC/HTLC_ERC.sol
@@ -17,12 +17,12 @@ contract HTLC_ERC is HTLCBase {
     }
 
     /// @dev Send ERC20 to the HTLC's recipient
-    function _transfer() internal override virtual {
+    function _transferAsWithdraw() internal override virtual {
         SafeERC20.safeTransfer(token, recipient, amount);
     }
 
     /// @dev Send back ERC20 to the HTLC's creator
-    function _refund() internal override virtual {
+    function _transferAsRefund() internal override virtual {
         SafeERC20.safeTransfer(token, from, amount);
     }
 

--- a/evm/contracts/HTLC/HTLC_ETH.sol
+++ b/evm/contracts/HTLC/HTLC_ETH.sol
@@ -30,13 +30,13 @@ contract HTLC_ETH is HTLCBase {
     }
 
     /// @dev Send ethers to the HTLC's recipient
-    function _transfer() override virtual internal {
+    function _transferAsWithdraw() override virtual internal {
         (bool sent,) = recipient.call{value: amount}("");
         require(sent, "ETH transfer failed - withdraw");
     }
 
     /// @dev Send back ethers to the HTLC's creator
-    function _refund() override virtual internal {
+    function _transferAsRefund() override virtual internal {
         (bool sent,) = from.call{value: amount}("");
         require(sent, "ETH transfer failed - refund");
     }

--- a/evm/contracts/HTLC/SignedHTLC_ERC.sol
+++ b/evm/contracts/HTLC/SignedHTLC_ERC.sol
@@ -40,4 +40,23 @@ contract SignedHTLC_ERC is HTLC_ERC {
     function withdraw(bytes32) override pure external {
         revert InvalidSignature();
     }
+
+    function refund(bytes32 _secret, bytes32 _r, bytes32 _s, uint8 _v) external {
+        bytes32 sigHash = ECDSA.toEthSignedMessageHash(_secret);
+        address signer = ECDSA.recover(sigHash, _v, _r, _s);
+
+        if (signer != poolSigner) {
+            revert InvalidSignature();
+        }
+
+        if (sha256(abi.encodePacked(_secret)) != hash) {
+            revert InvalidSecret();
+        }
+        _refund();
+    }
+
+    /// @dev Prevent to use the direct refund's function without the signature
+    function refund() override pure external {
+        revert InvalidSignature();
+    }
  }

--- a/evm/contracts/HTLC/SignedHTLC_ERC.sol
+++ b/evm/contracts/HTLC/SignedHTLC_ERC.sol
@@ -43,7 +43,7 @@ contract SignedHTLC_ERC is HTLC_ERC {
     }
 
     function refund(bytes32 _secret, bytes32 _r, bytes32 _s, uint8 _v) external {
-        bytes32 messagePayload = keccak256(abi.encodePacked(_secret, "refund"));
+        bytes32 messagePayload = keccak256(bytes.concat(_secret, "refund"));
         bytes32 signedMessageHash = ECDSA.toEthSignedMessageHash(messagePayload);
         address signer = ECDSA.recover(signedMessageHash, _v, _r, _s);
 

--- a/evm/contracts/HTLC/SignedHTLC_ETH.sol
+++ b/evm/contracts/HTLC/SignedHTLC_ETH.sol
@@ -44,7 +44,7 @@ contract SignedHTLC_ETH is HTLC_ETH {
     /// @notice Refund the HTLC contract upon the Archethic's pool signature
     /// @dev Signature verification is done before to do the usual refund flow of the HTLC
     function refund(bytes32 _secret, bytes32 _r, bytes32 _s, uint8 _v) external {
-        bytes32 messagePayload = keccak256(abi.encodePacked(_secret, "refund"));
+        bytes32 messagePayload = keccak256(bytes.concat(_secret, "refund"));
         bytes32 signedMessageHash = ECDSA.toEthSignedMessageHash(messagePayload);
         address signer = ECDSA.recover(signedMessageHash, _v, _r, _s);
 

--- a/evm/contracts/HTLC/SignedHTLC_ETH.sol
+++ b/evm/contracts/HTLC/SignedHTLC_ETH.sol
@@ -39,4 +39,26 @@ contract SignedHTLC_ETH is HTLC_ETH {
     function withdraw(bytes32) override pure external {
         revert InvalidSignature();
     }
+
+    /// @notice Refund the HTLC contract upon the Archethic's pool signature
+    /// @dev Signature verification is done before to do the usual refund flow of the HTLC
+    function refund(bytes32 _secret, bytes32 _r, bytes32 _s, uint8 _v) external {
+        bytes32 sigHash = ECDSA.toEthSignedMessageHash(_secret);
+        address signer = ECDSA.recover(sigHash, _v, _r, _s);
+
+        if (signer != poolSigner) {
+            revert InvalidSignature();
+        }
+
+        if (sha256(abi.encodePacked(_secret)) != hash) {
+            revert InvalidSecret();
+        }
+
+        _refund();
+    }
+
+    /// @dev Prevent to use the direct refund's function without the signature
+    function refund() override pure external {
+        revert InvalidSignature();
+    }
  }

--- a/evm/scripts/test/htlc_info.js
+++ b/evm/scripts/test/htlc_info.js
@@ -1,0 +1,47 @@
+const { ethers } = require("hardhat");
+const readline = require("readline").createInterface({
+  input: process.stdin,
+  output: process.stdout
+})
+
+async function requestContractAddress() {
+  return new Promise(r => {
+    readline.question("HTLC address: ", input => {
+      readline.close()
+      r(input)
+    })
+  })
+}
+
+async function main() {
+  const htlcAddress = await requestContractAddress()
+  const htlcContract = await ethers.getContractAt("HTLCBase", htlcAddress)
+
+  const lockTime = await htlcContract.lockTime()
+  console.log(lockTime)
+  const secretHash = await htlcContract.hash()
+  const amount = await htlcContract.amount()
+
+  let status
+  const htlcStatus = await htlcContract.status()
+  switch(htlcStatus.toString()) {
+    case "0": status = "pending"; break;
+    case "1": status = "withdrawn"; break;
+    case "2": status = "refunded"; break;
+  }
+
+  console.log("==============")
+  console.log("HTLC's endtime: ", lockTime.toString())
+  console.log("HTLC's hash: ", secretHash)
+  console.log("HTLC's amount: ", ethers.formatEther(amount))
+  console.log("HTLC's status: ", status)
+  console.log("HTLC's funding status", await htlcContract.enoughFunds() ? "Enough funds" : "Insufficient funds")
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1)
+    });
+

--- a/evm/scripts/test/refund.js
+++ b/evm/scripts/test/refund.js
@@ -1,0 +1,30 @@
+const { ethers } = require("hardhat");
+const readline = require("readline").createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+async function requestContractAddress() {
+  return new Promise((r) => {
+    readline.question("HTLC address: ", (input) => {
+      readline.close();
+      r(input);
+    });
+  });
+}
+
+async function main() {
+  const htlcAddress = await requestContractAddress();
+  const htlcContract = await ethers.getContractAt("HTLCBase", htlcAddress);
+
+  const tx = await htlcContract.refund();
+
+  console.log("tx address:", tx.hash);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/evm/test/HTLC/SignedHTLC_ERC.js
+++ b/evm/test/HTLC/SignedHTLC_ERC.js
@@ -2,6 +2,7 @@ const hre = require("hardhat");
 const { createHash, randomBytes } = require("crypto")
 const { loadFixture, time } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 const { expect } = require("chai");
+const { uintArrayToHex, hexToUintArray, concatUint8Arrays } = require("../utils")
 
 
 describe("Signed ERC HTLC", () => {
@@ -146,7 +147,12 @@ describe("Signed ERC HTLC", () => {
 
         await tokenInstance.transfer(HTLCInstance.getAddress(), amount)
 
-        const signature = ethers.Signature.from(await archPoolSigner.signMessage(secret))
+        const sigPayload = concatUint8Arrays([
+            secret,
+            new TextEncoder().encode("refund")
+        ])
+        const sigPayload2 = hexToUintArray(ethers.keccak256(`0x${uintArrayToHex(sigPayload)}`).slice(2))
+        const signature = ethers.Signature.from(await archPoolSigner.signMessage(sigPayload2))
 
         await time.increaseTo(lockTime + 5)
 

--- a/evm/test/HTLC/SignedHTLC_ETH.js
+++ b/evm/test/HTLC/SignedHTLC_ETH.js
@@ -39,7 +39,7 @@ describe("Signed ETH HTLC", (accounts) => {
         )
     })
 
-    it("should return an error if the signature is invalid", async () => {
+    it("should return an error if the signature is invalid for a withdraw", async () => {
         const archPoolSigner = ethers.Wallet.createRandom()
         const accounts = await ethers.getSigners()
 
@@ -70,4 +70,67 @@ describe("Signed ETH HTLC", (accounts) => {
         .to.be.revertedWithCustomError(HTLCInstance, "InvalidSignature")
     })
 
+    it ("should return an error if the signature is invalid for a refund", async () => {
+        const archPoolSigner = ethers.Wallet.createRandom()
+        const accounts = await ethers.getSigners()
+
+        const secret = randomBytes(32)
+
+        const hash = createHash("sha256")
+            .update(secret)
+            .digest()
+
+        const blockTimestamp = await time.latest()
+        const lockTime = blockTimestamp + 60
+
+        const amount = ethers.parseEther("1.0")
+
+        const HTLCInstance = await ethers.deployContract("SignedHTLC_ETH", [
+            accounts[2].address,
+            amount,
+            `0x${hash.toString('hex')}`,
+            lockTime,
+            archPoolSigner.address
+        ], { value: amount })
+
+        const signature = ethers.Signature.from(await archPoolSigner.signMessage(randomBytes(32)))
+
+        await expect(
+            HTLCInstance.refund(`0x${secret.toString('hex')}`, signature.r, signature.s, signature.v)
+        )
+        .to.be.revertedWithCustomError(HTLCInstance, "InvalidSignature")
+    })
+
+    it ("should refund after the signature is checked", async () => {
+        const archPoolSigner = ethers.Wallet.createRandom()
+        const accounts = await ethers.getSigners()
+
+        const secret = randomBytes(32)
+
+        const hash = createHash("sha256")
+            .update(secret)
+            .digest()
+
+        const blockTimestamp = await time.latest()
+        const lockTime = blockTimestamp + 1
+
+        const amount = ethers.parseEther("1.0")
+
+        const HTLCInstance = await ethers.deployContract("SignedHTLC_ETH", [
+            accounts[2].address,
+            amount,
+            `0x${hash.toString('hex')}`,
+            lockTime,
+            archPoolSigner.address
+        ], { value: amount })
+
+        const signature = ethers.Signature.from(await archPoolSigner.signMessage(secret))
+
+        await time.increaseTo(lockTime + 5)
+
+        await expect(
+            HTLCInstance.refund(`0x${secret.toString('hex')}`, signature.r, signature.s, signature.v)
+        )
+        .to.emit(HTLCInstance, "Refunded")
+    })
 })

--- a/evm/test/HTLC/SignedHTLC_ETH.js
+++ b/evm/test/HTLC/SignedHTLC_ETH.js
@@ -2,6 +2,8 @@ const hre = require("hardhat");
 const { createHash, randomBytes } = require("crypto")
 const { expect } = require("chai");
 const { time } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+const { uintArrayToHex, hexToUintArray, concatUint8Arrays } = require("../utils")
+
 
 describe("Signed ETH HTLC", (accounts) => {
 
@@ -124,7 +126,13 @@ describe("Signed ETH HTLC", (accounts) => {
             archPoolSigner.address
         ], { value: amount })
 
-        const signature = ethers.Signature.from(await archPoolSigner.signMessage(secret))
+        const sigPayload = concatUint8Arrays([
+            secret,
+            new TextEncoder().encode("refund")
+        ])
+        const sigPayload2 = hexToUintArray(ethers.keccak256(`0x${uintArrayToHex(sigPayload)}`).slice(2))
+
+        const signature = ethers.Signature.from(await archPoolSigner.signMessage(sigPayload2))
 
         await time.increaseTo(lockTime + 5)
 


### PR DESCRIPTION
This PR aims to provide a way to ensure the refund on the second chain of the swap is done only after the refund on the first chain have been performed.

- [x] EVM signature from Archethic's pool in the SignedHTLC contracts
- [x] Provide signature for EVM's SignedHTLC contracts
- [x] Implement check on Archethic's contract to ensure EVM refund have been performed