### PR TITLE
Add contract references in the pools

### DIFF
--- a/archethic/commands/test/refund_chargeable.js
+++ b/archethic/commands/test/refund_chargeable.js
@@ -10,11 +10,6 @@ const builder = {
     demandOption: true,
     type: "string",
   },
-  evm_contract: {
-    describe: "The HTLC EVM contract address",
-    demandOption: true,
-    type: "string",
-  },
   env: {
     describe: "The environment config to use (default to local)",
     demandOption: false,
@@ -22,12 +17,11 @@ const builder = {
   },
 };
 
-const handler = async function (argv) {
+const handler = async function(argv) {
   const envName = argv["env"] ? argv["env"] : "local";
   const env = config.environments[envName];
 
   const htlcAddress = argv["htlc_address"];
-  const evm_contract = argv["evm_contract"];
 
   const archethic = new Archethic(env.endpoint);
   await archethic.connect();
@@ -44,7 +38,7 @@ const handler = async function (argv) {
   const tx = archethic.transaction
     .new()
     .setType("transfer")
-    .addRecipient(htlcAddress, "refund", [evm_contract])
+    .addRecipient(htlcAddress, "refund", [])
     .build(env.userSeed, index)
     .originSign(Utils.originPrivateKey);
 

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -185,6 +185,10 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
 
     Contract.set_code next_code
   end
+
+  export fun get_pool() do
+    0x#{pool_address}
+  end
   """
 end
 
@@ -308,6 +312,10 @@ export fun get_signed_htlc(user_address, pool_address, token, amount) do
       Contract.set_code next_code
     end
 
+    export fun get_pool() do
+      0x#{pool_address}
+    end
+
     export fun get_htlc_data() do
       [
         amount: #{user_amount},
@@ -340,6 +348,10 @@ export fun get_signed_htlc(user_address, pool_address, token, amount) do
     \"""
 
     Contract.set_code next_code
+  end
+
+  export fun get_pool() do
+    0x#{pool_address}
   end
   """
 end

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -161,8 +161,9 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
       Contract.set_code ""
     end
 
-    export fun get_provision_signature() do
+    export fun get_provision_data() do
         [
+          evm_contract: #{evm_contract},
           signature: [
             r: 0x\#{signature.r},
             s: 0x\#{signature.s},

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -163,7 +163,7 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
 
     export fun get_provision_data() do
         [
-          evm_contract: #{evm_contract},
+          evm_contract: "\#{evm_contract}",
           signature: [
             r: 0x\#{signature.r},
             s: 0x\#{signature.s},

--- a/archethic/contracts/factory.exs
+++ b/archethic/contracts/factory.exs
@@ -87,13 +87,6 @@ export fun get_chargeable_htlc(end_time, user_address, pool_address, secret_hash
   after_provision_code = """
     @version 1
 
-    # Automate the refunding after the given timestamp
-    actions triggered_by: datetime, at: #{end_time} do
-      Contract.set_type "transfer"
-      #{return_transfer_code}
-      Contract.set_code ""
-    end
-
     condition triggered_by: transaction, on: refund(), as: [
       content: (
         valid? = false
@@ -281,11 +274,6 @@ export fun get_signed_htlc(user_address, pool_address, token, amount) do
 
   after_secret_code = """
     @version 1
-    # Automate the refunding after the given timestamp
-    actions triggered_by: datetime, at: \#{end_time} do
-      htlc_genesis_address = Chain.get_genesis_address(contract.address)
-      Contract.add_recipient(address: 0x#{pool_address}, action: "refund", args: [htlc_genesis_address])
-    end
 
     condition triggered_by: transaction, on: refund(secret, secret_signature), as: [
       previous_public_key: (

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -132,8 +132,12 @@ actions triggered_by: transaction, on: request_secret_hash(htlc_genesis_address,
   secret = Crypto.hmac(transaction.address)
   secret_hash = Crypto.hash(secret, "sha256")
 
-  # Build signature for EVM decryption
-  signature = sign_for_evm(secret_hash, chain_id)
+  # Perform a first hash to combine data and chain_id
+  abi_data = Evm.abi_encode("(bytes32, bytes32,uint)", [Crypto.hash(htlc_genesis_address), secret_hash, chain_id])
+  signature_data = Crypto.hash(abi_data, "keccak256")
+
+  # Build signature for EVM verification
+  signature = sign_for_evm(signature_data)
 
   # Calculate endtime now + 2 hours
   now = Time.now()

--- a/archethic/contracts/token_pool.exs
+++ b/archethic/contracts/token_pool.exs
@@ -127,7 +127,6 @@ condition triggered_by: transaction, on: request_secret_hash(htlc_genesis_addres
 actions triggered_by: transaction, on: request_secret_hash(htlc_genesis_address, amount, _user_address, chain_id) do
   # Here delete old secret that hasn't been used before endTime
   requested_secrets = State.get("requested_secrets", Map.new())
-  requested_secrets = delete_unused_secrets(requested_secrets)
 
   secret = Crypto.hmac(transaction.address)
   secret_hash = Crypto.hash(secret, "sha256")
@@ -370,18 +369,6 @@ fun delete_old_charged_contracts(charged_contracts) do
   end
 
   charged_contracts
-end
-
-fun delete_unused_secrets(requested_secrets) do
-  for address in Map.keys(requested_secrets) do
-    htlc_map = Map.get(requested_secrets, address)
-
-    if htlc_map.end_time <= Time.now() do
-      requested_secrets = Map.delete(requested_secrets, address)
-    end
-  end
-
-  requested_secrets
 end
 
 fun valid_chargeable_code?(end_time, amount, user_address, secret_hash) do

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -117,7 +117,7 @@ actions triggered_by: transaction, on: request_secret_hash(htlc_genesis_address,
   secret_hash = Crypto.hash(secret, "sha256")
 
   # Perform a first hash to combine data and chain_id
-  abi_data = Evm.abi_encode("(bytes32,uint)", [secret_hash, chain_id])
+  abi_data = Evm.abi_encode("(bytes32, bytes32,uint)", [Crypto.hash(htlc_genesis_address), secret_hash, chain_id])
   signature_data = Crypto.hash(abi_data, "keccak256")
 
   # Build signature for EVM verification

--- a/archethic/contracts/uco_pool.exs
+++ b/archethic/contracts/uco_pool.exs
@@ -111,7 +111,6 @@ condition triggered_by: transaction, on: request_secret_hash(htlc_genesis_addres
 actions triggered_by: transaction, on: request_secret_hash(htlc_genesis_address, amount, _user_address, chain_id) do
   # Here delete old secret that hasn't been used before endTime
   requested_secrets = State.get("requested_secrets", Map.new())
-  requested_secrets = delete_unused_secrets(requested_secrets)
 
   secret = Crypto.hmac(transaction.address)
   secret_hash = Crypto.hash(secret, "sha256")
@@ -355,18 +354,6 @@ fun delete_old_charged_contracts(charged_contracts) do
   end
 
   charged_contracts
-end
-
-fun delete_unused_secrets(requested_secrets) do
-  for address in Map.keys(requested_secrets) do
-    htlc_map = Map.get(requested_secrets, address)
-
-    if htlc_map.end_time <= Time.now() do
-      requested_secrets = Map.delete(requested_secrets, address)
-    end
-  end
-
-  requested_secrets
 end
 
 fun valid_chargeable_code?(end_time, amount, user_address, secret_hash) do

--- a/evm/contracts/mock/PoolBaseV2.sol
+++ b/evm/contracts/mock/PoolBaseV2.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.21;
 
 import "../Pool/PoolBase.sol";
 
-contract PoolBaseV2 is PoolBase {
-    
+abstract contract PoolBaseV2 is PoolBase {
+
     function setSafetyModuleFeeRate(uint256 _safetyFeeRate) onlyOwner override external {
         safetyModuleFeeRate = _safetyFeeRate * 2;
         emit SafetyModuleFeeRateChanged(_safetyFeeRate * 2);

--- a/evm/interfaces/IPool.sol
+++ b/evm/interfaces/IPool.sol
@@ -11,7 +11,7 @@ interface IPool {
     /// @param _r Signature's R part
     /// @param _s Signature's S part
     /// @param _v SIgnature's recovery part
-    function provisionHTLC(bytes32 _hash, uint256 _amount, uint _lockTime, bytes32 _r, bytes32 _s, uint8 _v) external;
+    function provisionHTLC(bytes32 _hash, uint256 _amount, uint _lockTime, bytes memory _archethicHTLCAddress, bytes32 _r, bytes32 _s, uint8 _v) external;
 
     /// @notice Mint an HTLC contract by specifying the reserve and safety module as recipient of the HTLC and chargeable in fee for the safety module.
     /// @param _hash Secret's hash of the HTLC
@@ -81,4 +81,16 @@ interface IPool {
     /// @notice Return a minted swap by its secret's hash
     /// @return htlc Address of the HTLC's contract
     function mintedSwap(bytes32 _hash) external returns (IHTLC);
+
+    enum SwapType { CHARGEABLE_HTLC, SIGNED_HTLC }
+
+    struct Swap {
+        address evmAddress;
+        bytes archethicAddress;
+        SwapType swapType;
+    }
+
+    /// @notice Return the list of swaps by owner's address
+    /// @return swaps List of swaps, including EVM & Archethic's htlc address & Swap's type: Chargeable (From EVM) or Signed (To Evm)
+    function getSwapsByOwner(address owner) external view returns (Swap[] memory swaps);
 }

--- a/evm/scripts/cli/deploy_erc_signed_htlc.js
+++ b/evm/scripts/cli/deploy_erc_signed_htlc.js
@@ -6,6 +6,14 @@ const readline = require("readline").createInterface({
     output: process.stdout
 })
 
+async function promptArchethicHTLCAddress() {
+    return new Promise(r => {
+        readline.question("Archethic HTLC address: ", input => {
+            r(input)
+        })
+    })
+}
+
 async function promptSecretHash() {
     return new Promise(r => {
         readline.question("Secret hash (with 0x): ", input => {
@@ -60,10 +68,11 @@ async function main() {
     const lockTimeUnix = await promptEndTime()
     const hash = await promptSecretHash()
     const signature = await promptSignature()
+    const archethicHTLCAddress = await promptArchethicHTLCAddress()
 
     const pool = await ethers.getContractAt("ERCPool", poolAddr)
 
-    const tx = await pool.provisionHTLC(hash, amount, lockTimeUnix, signature.r, signature.s, signature.v)
+    const tx = await pool.provisionHTLC(hash, amount, lockTimeUnix, `0x${archethicHTLCAddress}`, signature.r, signature.s, signature.v)
     const htlcContract = await pool.provisionedSwap(hash)
 
     console.log(`HTLC CONTRACT address: ${htlcContract}`)
@@ -76,5 +85,3 @@ main()
         console.error(error);
         process.exit(1)
     });
-
-

--- a/evm/scripts/cli/deploy_eth_signed_htlc.js
+++ b/evm/scripts/cli/deploy_eth_signed_htlc.js
@@ -7,6 +7,14 @@ const readline = require("readline").createInterface({
     output: process.stdout
 })
 
+async function promptArchethicHTLCAddress() {
+    return new Promise(r => {
+        readline.question("Archethic HTLC address: ", input => {
+            r(input)
+        })
+    })
+}
+
 async function promptSecretHash() {
     return new Promise(r => {
         readline.question("secret hash (with 0x): ", input => {
@@ -64,9 +72,10 @@ async function main() {
     const lockTimeUnix = await promptEndTime()
     const hash = await promptSecretHash()
     const signature = await promptSignature()
+    const archethicHTLCAddress = await promptArchethicHTLCAddress()
 
     const pool = await ethers.getContractAt("ETHPool", poolAddress)
-    const tx = await pool.provisionHTLC(hash, amount, lockTimeUnix, signature.r, signature.s, signature.v, { gasLimit: 10000000 })
+    const tx = await pool.provisionHTLC(hash, amount, lockTimeUnix, `0x${archethicHTLCAddress}`, signature.r, signature.s, signature.v, { gasLimit: 10000000 })
     const htlcContract = await pool.provisionedSwap(hash)
     console.log(`HTLC CONTRACT address: ${htlcContract}`)
     console.log(`HTLC TX address: ${tx.hash}`)

--- a/evm/scripts/cli/reveal_chargeable_secret.js
+++ b/evm/scripts/cli/reveal_chargeable_secret.js
@@ -42,8 +42,9 @@ async function main() {
     contractAddress,
   );
 
-  await htlc.withdraw(secret, signature.r, signature.s, signature.v);
-  console.log("Withdraw successful");
+  return htlc.withdraw(secret, signature.r, signature.s, signature.v)
+    .then(() => console.log("Withdraw successful"))
+    .catch(er => console.log(er.message))
 }
 
 main()

--- a/evm/test/Pool/ERCPool.js
+++ b/evm/test/Pool/ERCPool.js
@@ -66,8 +66,12 @@ describe("ERC LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -81,6 +85,7 @@ describe("ERC LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -111,8 +116,12 @@ describe("ERC LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -126,6 +135,7 @@ describe("ERC LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -180,4 +190,3 @@ describe("ERC LiquidityPool", () => {
         expect(await HTLCInstance.refillAmount()).to.equal(0)
     })
 })
-

--- a/evm/test/Pool/ETHPool.js
+++ b/evm/test/Pool/ETHPool.js
@@ -134,8 +134,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -149,6 +153,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -157,6 +162,10 @@ describe("ETH LiquidityPool", () => {
         await expect(tx).to.emit(pool, "ContractProvisioned")
 
         const htlcAddress = await pool.provisionedSwap("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        const provisionedSwaps = await pool.getSwapsByOwner(accounts[0].address)
+        expect(provisionedSwaps[0][0]).to.equal(htlcAddress)
+        expect(provisionedSwaps[0][1]).to.equal(`0x${archethicHtlcAddress}`)
+        expect(provisionedSwaps[0][2]).to.equal(1)
 
         await expect(tx)
             .to.changeEtherBalance(htlcAddress, ethers.parseEther("1"))
@@ -183,8 +192,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -195,6 +208,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -213,8 +227,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -225,6 +243,7 @@ describe("ETH LiquidityPool", () => {
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -243,8 +262,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -255,6 +278,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('0'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -270,8 +294,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -282,6 +310,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             0,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -292,6 +321,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             await time.latest() - 10, // Before the latest block
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -302,6 +332,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             await time.latest() + 90000, // More than 1 day from the latest block
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -322,8 +353,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -337,6 +372,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -346,6 +382,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -361,17 +398,8 @@ describe("ETH LiquidityPool", () => {
             value: ethers.parseEther("2.0"),
         });
 
-        const buffer = new ArrayBuffer(32);
-        const view = new DataView(buffer);
-        view.setUint32(0x0, networkConfig.chainId, true);
-        const networkIdUint8Array = new Uint8Array(buffer).reverse();
-
-        const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
-            networkIdUint8Array
-        ])
-
         const signature = ethers.Signature.from(await archPoolSigner.signMessage(randomBytes(32)))
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
 
         const blockTimestamp = await time.latest()
         const lockTime = blockTimestamp + 60
@@ -380,6 +408,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -395,8 +424,12 @@ describe("ETH LiquidityPool", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -410,6 +443,7 @@ describe("ETH LiquidityPool", () => {
             "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
             ethers.parseEther('1'),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v
@@ -444,6 +478,11 @@ describe("ETH LiquidityPool", () => {
         const roundedTimestamp = nowTimestamp - (nowTimestamp % 60)
 
         expect(ethers.toBigInt(lockTime) - ethers.toBigInt(roundedTimestamp) >= 60).to.be.true
+
+        const swaps = await pool.getSwapsByOwner(accounts[0].address)
+        expect(swaps[0][0]).to.equal(htlcAddress)
+        expect(swaps[0][1]).to.equal("0x")
+        expect(swaps[0][2]).to.equal(0)
     })
 
     it("should mint and send funds to the HTLC contract with fee handling low decimals", async () => {
@@ -512,4 +551,3 @@ describe("ETH LiquidityPool", () => {
             .to.be.revertedWithCustomError(pool, "InvalidAmount")
     })
 })
-

--- a/evm/test/Proxy.js
+++ b/evm/test/Proxy.js
@@ -52,8 +52,12 @@ describe("LP Proxy", () => {
         view.setUint32(0x0, networkConfig.chainId, true);
         const networkIdUint8Array = new Uint8Array(buffer).reverse();
 
+        const archethicHtlcAddress = "00004970e9862b17e9b9441cdbe7bc13aeb4c906a75030bb261df1f87b4af9ee11a5"
+        const archethicHtlcAddressHash = ethers.sha256(`0x${archethicHtlcAddress}`)
+
         const sigPayload = concatUint8Arrays([
-            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+            hexToUintArray(archethicHtlcAddressHash.slice(2)), // Archethic HTLC's address hash
+            hexToUintArray("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"), // HTLC's hash
             networkIdUint8Array
         ])
 
@@ -64,9 +68,10 @@ describe("LP Proxy", () => {
         const lockTime = blockTimestamp + 60
 
         await proxy.provisionHTLC(
-            "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", 
-            ethers.parseEther("1.0"), 
+            "0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            ethers.parseEther("1.0"),
             lockTime,
+            `0x${archethicHtlcAddress}`,
             signature.r,
             signature.s,
             signature.v)
@@ -100,4 +105,3 @@ describe("LP Proxy", () => {
         expect(await proxy.safetyModuleFeeRate()).to.equal(1000)
     })
 })
-


### PR DESCRIPTION
This PR provides a reference of
- EVM contract in the Archethic pool for Chargeable Contracts
- Archethic contract in the EVM pool for the Signed contracts

It also expose a function to get the list of swaps by EVM's address and their associated type