### PR TITLE
Support multisig interaction

### DIFF
--- a/archethic/bridge.js
+++ b/archethic/bridge.js
@@ -8,6 +8,10 @@ import deploy_factory from "./commands/pool_management/deploy_factory.js";
 import update_pool from "./commands/pool_management/update_pool.js";
 import init_keychain from "./commands/pool_management/init_keychain.js";
 import derive_eth_address from "./commands/pool_management/derive_eth_address.js";
+import pool_code from "./commands/pool_management/pool_code.js";
+import deploy_multisig from "./commands/pool_management/deploy_multisig.js";
+import pool_address from "./commands/pool_management/pool_address.js";
+
 
 import deploy_chargeable_htlc from "./commands/test/deploy_chargeable_htlc.js";
 import deploy_signed_htlc from "./commands/test/deploy_signed_htlc.js";
@@ -25,7 +29,10 @@ y.command(deploy_pool).help();
 y.command(deploy_factory).help();
 y.command(update_pool).help();
 y.command(init_keychain).help();
+y.command(pool_code).help();
+y.command(deploy_multisig).help();
 y.command(derive_eth_address).help();
+y.command(pool_address).help();
 
 y.command(deploy_chargeable_htlc).help();
 y.command(deploy_signed_htlc).help();

--- a/archethic/commands/pool_management/deploy_multisig.js
+++ b/archethic/commands/pool_management/deploy_multisig.js
@@ -1,0 +1,91 @@
+import Archethic, { Utils } from "@archethicjs/sdk"
+import config from "../../config.js"
+import {
+  getServiceGenesisAddress,
+} from "../utils.js"
+
+import { getDeployTransaction } from "@archethicjs/multisig-sdk"
+
+const command = "deploy_multisig"
+const describe = "Deploy multisig for keychain master"
+const builder = {
+  initial_voter: {
+    describe: "The initial voter address",
+    demandOption: true, // Required
+    type: "string"
+  },
+  access_seed: {
+    describe: "The Keychain access seed (default in env config)",
+    demandOption: false,
+    type: "string"
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string"
+  }
+}
+
+const handler = async function(argv) {
+  const envName = argv["env"] ? argv["env"] : "local"
+  const env = config.environments[envName]
+
+  const keychainAccessSeed = argv["access_seed"] ? argv["access_seed"] : env.keychainAccessSeed
+
+  if (keychainAccessSeed == undefined) {
+    console.log("Keychain access seed not defined")
+    process.exit(1)
+  }
+
+  const initialVoter = argv["initial_voter"]
+
+  const archethic = new Archethic(env.endpoint)
+  await archethic.connect()
+
+  let keychain
+
+  try {
+    keychain = await archethic.account.getKeychain(keychainAccessSeed)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const masterGenesisAddress = getServiceGenesisAddress(keychain, "Master")
+
+  const storageNoncePublicKey = await archethic.network.getStorageNoncePublicKey();
+
+  const res = keychain.ecEncryptServiceSeed("Master", [storageNoncePublicKey])
+  const { secret, authorizedPublicKeys: authorizedKeys } = res
+  console.log("Master genesis address:", masterGenesisAddress)
+  const index = await archethic.transaction.getTransactionIndex(masterGenesisAddress)
+
+  let updateTx = getDeployTransaction(archethic, {
+    voters: [ initialVoter ],
+    confirmationThreshold: 1,
+  }, secret, authorizedKeys)
+
+  updateTx = keychain.buildTransaction(updateTx, "Master", index).originSign(Utils.originPrivateKey)
+
+  updateTx.on("fullConfirmation", async (_confirmations) => {
+    const txAddress = Utils.uint8ArrayToHex(updateTx.address)
+    console.log("Transaction validated !")
+    console.log("Address:", txAddress)
+    console.log(env.endpoint + "/explorer/transaction/" + txAddress)
+    process.exit(0)
+  }).on("error", (context, reason) => {
+    console.log("Error while sending transaction")
+    console.log("Contest:", context)
+    console.log("Reason:", reason)
+    process.exit(1)
+  }).send()
+}
+
+
+
+export default {
+  command,
+  describe,
+  builder,
+  handler
+}

--- a/archethic/commands/pool_management/pool_address.js
+++ b/archethic/commands/pool_management/pool_address.js
@@ -1,0 +1,65 @@
+import Archethic from "@archethicjs/sdk"
+import config from "../../config.js"
+import {
+  getServiceGenesisAddress,
+  getPoolServiceName
+} from "../utils.js"
+
+const command = "pool_address"
+const describe = "Get pool address"
+const builder = {
+  token: {
+    describe: "The token to create a pool, UCO or token symbol",
+    demandOption: true, // Required
+    type: "string"
+  },
+  access_seed: {
+    describe: "The Keychain access seed (default in env config)",
+    demandOption: false,
+    type: "string"
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string"
+  }
+}
+
+const handler = async function(argv) {
+  const envName = argv["env"] ? argv["env"] : "local"
+  const env = config.environments[envName]
+
+  const keychainAccessSeed = argv["access_seed"] ? argv["access_seed"] : env.keychainAccessSeed
+
+  if (keychainAccessSeed == undefined) {
+    console.log("Keychain access seed not defined")
+    process.exit(1)
+  }
+
+  const archethic = new Archethic(env.endpoint)
+  await archethic.connect()
+
+  let keychain
+
+  try {
+    keychain = await archethic.account.getKeychain(keychainAccessSeed)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const token = argv["token"]
+  const serviceName = getPoolServiceName(token)
+
+  keychain.addService(serviceName, "m/650'/" + serviceName)
+  const poolGenesisAddress = getServiceGenesisAddress(keychain, serviceName)
+
+  console.log("Pool genesis address:", poolGenesisAddress)
+}
+
+export default {
+  command,
+  describe,
+  builder,
+  handler
+}

--- a/archethic/commands/pool_management/pool_code.js
+++ b/archethic/commands/pool_management/pool_code.js
@@ -1,0 +1,61 @@
+import Archethic from "@archethicjs/sdk"
+import { getPoolCode } from "../utils.js"
+import config from "../../config.js"
+
+const command = "pool_code"
+const describe = "Get the pool's code"
+const builder = {
+  token: {
+    describe: "The token to create a pool, UCO or token symbol",
+    demandOption: true, // Required
+    type: "string"
+  },
+  access_seed: {
+    describe: "The Keychain access seed (default in env config)",
+    demandOption: false,
+    type: "string"
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string"
+  }
+}
+
+const handler = async function(argv) {
+  const envName = argv["env"] ? argv["env"] : "local"
+  const token = argv["token"]
+
+  const env = config.environments[envName]
+
+  const keychainAccessSeed = argv["access_seed"] ? argv["access_seed"] : env.keychainAccessSeed
+
+  if (keychainAccessSeed == undefined) {
+    console.log("Keychain access seed not defined")
+    process.exit(1)
+  }
+
+  const archethic = new Archethic(env.endpoint)
+  await archethic.connect()
+
+  let keychain
+
+  try {
+    keychain = await archethic.account.getKeychain(keychainAccessSeed)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const poolCode = getPoolCode(envName, keychain, token)
+  console.log(poolCode)
+  process.exit(0)
+}
+
+
+export default {
+  command,
+  describe,
+  builder,
+  handler
+}

--- a/archethic/commands/pool_management/update_pool.js
+++ b/archethic/commands/pool_management/update_pool.js
@@ -84,8 +84,11 @@ const handler = async function(argv) {
           state
         }
       }`)
-      const { state: oldState} = res.chainUnspentOutputs.find(x => x.state != null)
-      const nextTxID = oldState.transaction_id + 1
+      const resState = res.chainUnspentOutputs.find(x => x.state != null)
+      let nextTxID = 1
+      if (resState && resState.state) {
+        nextTxID = resState.state.transaction_id + 1
+      }
 
       if(archethic.rpcWallet) {
         const { transactionAddress } = await archethic.rpcWallet.sendTransaction(updateTx)

--- a/archethic/commands/pool_management/update_pool.js
+++ b/archethic/commands/pool_management/update_pool.js
@@ -1,6 +1,7 @@
 import Archethic, { Utils } from "@archethicjs/sdk"
 import config from "../../config.js"
 import { getPoolCode, getServiceGenesisAddress, getPoolServiceName } from "../utils.js"
+import { getProposeTransaction } from "@archethicjs/multisig-sdk"
 
 const command = "update_pool"
 const describe = "Update an existing pool"
@@ -19,6 +20,11 @@ const builder = {
     describe: "The environment config to use (default to local)",
     demandOption: false,
     type: "string"
+  },
+  with_multisig: {
+    describe: "Determine if we need to use the multisig for the update",
+    demandOption: false,
+    type: "boolean"
   }
 }
 
@@ -33,52 +39,90 @@ const handler = async function(argv) {
     process.exit(1)
   }
 
-  const archethic = new Archethic(env.endpoint)
+  const withMultisig = argv["with_multisig"] == false ? false : true
+
+  const archethic = new Archethic(withMultisig ? undefined : env.endpoint)
+  if (archethic.rpcWallet) {
+    archethic.rpcWallet.setOrigin({ name: "Archethic Bridge CLI" });
+  }
   await archethic.connect()
 
   let keychain
 
   try {
     keychain = await archethic.account.getKeychain(keychainAccessSeed)
+
+    const token = argv["token"]
+    const serviceName = getPoolServiceName(token)
+    const poolGenesisAddress = getServiceGenesisAddress(keychain, serviceName)
+
+    const indexPool = await archethic.transaction.getTransactionIndex(poolGenesisAddress)
+    if (indexPool == 0) {
+      console.log("Pool doesn't exists !")
+      process.exit(1)
+    }
+
+    const poolCode = getPoolCode(envName, keychain, token)
+
+    const masterGenesisAddress = getServiceGenesisAddress(keychain, "Master")
+    console.log("Master genesis address:", masterGenesisAddress)
+    const index = await archethic.transaction.getTransactionIndex(masterGenesisAddress)
+
+    let updateTx
+    if (withMultisig) {
+      updateTx = getProposeTransaction(archethic, masterGenesisAddress, { recipients: [
+        { 
+          address: poolGenesisAddress,
+          action: "update_code",
+          args: [poolCode]
+        }
+      ] })
+
+      const res = await archethic.network.rawGraphQLQuery(`
+        query{
+        chainUnspentOutputs(address: "${masterGenesisAddress}") {
+          state
+        }
+      }`)
+      const { state: oldState} = res.chainUnspentOutputs.find(x => x.state != null)
+      const nextTxID = oldState.transaction_id + 1
+
+      if(archethic.rpcWallet) {
+        const { transactionAddress } = await archethic.rpcWallet.sendTransaction(updateTx)
+
+        console.log("Transaction validated !")
+        console.log("Address:", transactionAddress)
+        console.log(env.endpoint + "/explorer/transaction/" + transactionAddress)
+        console.log("Multisig Transaction ID", nextTxID)
+
+        process.exit(0)
+      }
+    }
+    else {
+      updateTx = archethic.transaction.new()
+        .setType("transfer")
+        .addRecipient(poolGenesisAddress, "update_code", [poolCode])
+
+      updateTx = keychain.buildTransaction(updateTx, "Master", index).originSign(Utils.originPrivateKey)
+    }
+
+    updateTx.on("fullConfirmation", async (_confirmations) => {
+      const txAddress = Utils.uint8ArrayToHex(updateTx.address)
+      console.log("Transaction validated !")
+      console.log("Address:", txAddress)
+      console.log(env.endpoint + "/explorer/transaction/" + txAddress)
+      process.exit(0)
+    }).on("error", (context, reason) => {
+      console.log("Error while sending transaction")
+      console.log("Contest:", context)
+      console.log("Reason:", reason)
+      process.exit(1)
+    }).send()
+
   } catch (err) {
     console.log(err)
     process.exit(1)
   }
-
-  const token = argv["token"]
-  const serviceName = getPoolServiceName(token)
-  const poolGenesisAddress = getServiceGenesisAddress(keychain, serviceName)
-
-  const indexPool = await archethic.transaction.getTransactionIndex(poolGenesisAddress)
-  if (indexPool == 0) {
-    console.log("Pool doesn't exists !")
-    process.exit(1)
-  }
-
-  const poolCode = getPoolCode(envName, keychain, token)
-
-  const masterGenesisAddress = getServiceGenesisAddress(keychain, "Master")
-  console.log("Master genesis address:", masterGenesisAddress)
-  const index = await archethic.transaction.getTransactionIndex(masterGenesisAddress)
-
-  let updateTx = archethic.transaction.new()
-    .setType("transfer")
-    .addRecipient(poolGenesisAddress, "update_code", [poolCode])
-
-  updateTx = keychain.buildTransaction(updateTx, "Master", index).originSign(Utils.originPrivateKey)
-
-  updateTx.on("fullConfirmation", async (_confirmations) => {
-    const txAddress = Utils.uint8ArrayToHex(updateTx.address)
-    console.log("Transaction validated !")
-    console.log("Address:", txAddress)
-    console.log(env.endpoint + "/explorer/transaction/" + txAddress)
-    process.exit(0)
-  }).on("error", (context, reason) => {
-    console.log("Error while sending transaction")
-    console.log("Contest:", context)
-    console.log("Reason:", reason)
-    process.exit(1)
-  }).send()
 }
 
 export default {

--- a/archethic/package-lock.json
+++ b/archethic/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@archethicjs/multisig-sdk": "^1.0.10",
         "@archethicjs/sdk": "^1.21.2",
         "cli-progress": "^3.12.0",
         "keccak256": "^1.0.6",
@@ -33,10 +34,20 @@
         "phoenix": "^1.4.0"
       }
     },
+    "node_modules/@archethicjs/multisig-sdk": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@archethicjs/multisig-sdk/-/multisig-sdk-1.0.10.tgz",
+      "integrity": "sha512-uvV0jWhsXZpVsu1snA5ngSS8M5/UF76P0kHA5QSWObOJZlIFj/fU8XD2h9rpsgGgsO+OT2ypDqZjpaRDwTolig==",
+      "license": "AGPL-3",
+      "dependencies": {
+        "@archethicjs/sdk": "^1.21.2"
+      }
+    },
     "node_modules/@archethicjs/sdk": {
       "version": "1.21.2",
       "resolved": "https://registry.npmjs.org/@archethicjs/sdk/-/sdk-1.21.2.tgz",
       "integrity": "sha512-uD5TyUKaIZPmJcCeW3wZJfhpAxp/6lRZKGjyueHFEV4U6fmJyp21A7OwGyEuQ39k3Hz7GCba7R7yoh2HE+4iXQ==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@absinthe/socket": "^0.2.1",
         "blakejs": "^1.2.1",

--- a/archethic/package.json
+++ b/archethic/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@archethicjs/multisig-sdk": "^1.0.10",
     "@archethicjs/sdk": "^1.21.2",
     "cli-progress": "^3.12.0",
     "keccak256": "^1.0.6",


### PR DESCRIPTION
This PR supports multisig for bridge contracts management.
 It adds three commands:
- deploy_multisig: convert the master chain into a multisig
- pool_code: to get the pool code with template variables replacements
- pool_address: to get the address of a pool from the keychain service derivations

To test this PR:
- Init the keychain: `node bridge.js init_keychain`
- Deploy the factory: `node bridge.js deploy_factory`
- Change the master to multisig: `node bridge.js deploy_multisig`
- Get the pool address: `node bridge.js pool_address --token UCO`
- Fund this address (either via multisig or faucet)
- Deploy the pool without the initial funding: `node bridge.js deploy_pool --token UCO --with_funding false`
- To update the pool with multisig: `node bridge.js update_pool --token UCO --with_multisig`
- Confirm the multisig transaction
   - Through the [UI](https://github.com/archethic-foundation/multisig/tree/main/packages/app)
   - Using the [CLI](https://github.com/archethic-foundation/multisig/tree/main/packages/cli): ` node multisig.js confirm-transaction`
   
